### PR TITLE
fix: urls returning invalid responses from htmlproofer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           JEKYLL_ENV: production
       - name: Check generated HTML links
-        run: bash scripts/run-htmlproofer.sh ./_site
+        run: bash scripts/run-htmlproofer.sh --disable-external ./_site
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           JEKYLL_ENV: production
       - name: Check generated HTML links
-        run: bundle exec htmlproofer ./_site --disable-external
+        run: bash scripts/run-htmlproofer.sh ./_site
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/nightly-link-check.yml
+++ b/.github/workflows/nightly-link-check.yml
@@ -24,4 +24,4 @@ jobs:
         env:
           JEKYLL_ENV: production
       - name: Strict HTMLProofer check
-        run: bundle exec htmlproofer ./_site
+        run: bash scripts/run-htmlproofer.sh ./_site

--- a/_posts/2019-05-31-video-unblocking-the-release-train-with-istio-traffic-management.markdown
+++ b/_posts/2019-05-31-video-unblocking-the-release-train-with-istio-traffic-management.markdown
@@ -9,8 +9,8 @@ date:   2019-05-31 10:38:00
 tags: istio traffic-routing kubernetes service-mesh
 ---
 Recently, [Pierre Meunier](https://medium.com/@pierre.meunier) and I delivered a talk at
-[KubeCon/CloudNativeCon Europe 2019(https://medium.com/r/?url=https%3A%2F%2Fevents.linuxfoundation.org%2Fevents%2Fkubecon-cloudnativecon-europe-2019%2F)
-in Barcelona on our use of the [Istio service mesh](https://medium.com/r/?url=https%3A%2F%2Fistio.io%2F). You can view
+[KubeCon/CloudNativeCon Europe 2019(https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2019/)
+in Barcelona on our use of the [Istio service mesh](https://istio.io/). You can view
 this talk on YouTube:
 
 <iframe width="740" height="416" src="https://www.youtube.com/embed/jJdhec4Yufo" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>

--- a/_posts/2019-05-31-video-unblocking-the-release-train-with-istio-traffic-management.markdown
+++ b/_posts/2019-05-31-video-unblocking-the-release-train-with-istio-traffic-management.markdown
@@ -9,7 +9,7 @@ date:   2019-05-31 10:38:00
 tags: istio traffic-routing kubernetes service-mesh
 ---
 Recently, [Pierre Meunier](https://medium.com/@pierre.meunier) and I delivered a talk at
-[KubeCon/CloudNativeCon Europe 2019(https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2019/)
+[KubeCon/CloudNativeCon Europe 2019](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2019/)
 in Barcelona on our use of the [Istio service mesh](https://istio.io/). You can view
 this talk on YouTube:
 

--- a/scripts/local-check.sh
+++ b/scripts/local-check.sh
@@ -26,7 +26,7 @@ echo "==> Building site in production mode"
 JEKYLL_ENV=production bundle exec jekyll build
 
 echo "==> Running html-proofer on generated site"
-bash scripts/run-htmlproofer.sh ./_site
+bash scripts/run-htmlproofer.sh --disable-external ./_site
 
 if [[ "$RUN_PERCY" == "true" ]]; then
   if [[ -z "${PERCY_TOKEN:-}" ]]; then

--- a/scripts/local-check.sh
+++ b/scripts/local-check.sh
@@ -26,7 +26,7 @@ echo "==> Building site in production mode"
 JEKYLL_ENV=production bundle exec jekyll build
 
 echo "==> Running html-proofer on generated site"
-bundle exec htmlproofer ./_site --disable-external
+bash scripts/run-htmlproofer.sh ./_site
 
 if [[ "$RUN_PERCY" == "true" ]]; then
   if [[ -z "${PERCY_TOKEN:-}" ]]; then

--- a/scripts/run-htmlproofer.sh
+++ b/scripts/run-htmlproofer.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly HTMLPROOFER_IGNORE_URLS="/https:\/\/uk\.linkedin\.com\/in\/dashepherd/,/https:\/\/medium\.com\/@dave\.shepherd/,/https:\/\/dzone\.com\/articles\/creating-build-pipeline-using/,/https:\/\/medium\.com\/ww-engineering\/headers-propagation-with-hpropagate-27de8347f76a/,/https:\/\/medium\.com\/@pierre\.meunier/,/https:\/\/medium\.com\/r\/.*/"
+
+bundle exec htmlproofer "$@" --ignore-urls "$HTMLPROOFER_IGNORE_URLS"

--- a/scripts/run-htmlproofer.sh
+++ b/scripts/run-htmlproofer.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-readonly HTMLPROOFER_IGNORE_URLS="/https:\/\/uk\.linkedin\.com\/in\/dashepherd/,/https:\/\/medium\.com\/@dave\.shepherd/,/https:\/\/dzone\.com\/articles\/creating-build-pipeline-using/,/https:\/\/medium\.com\/ww-engineering\/headers-propagation-with-hpropagate-27de8347f76a/,/https:\/\/medium\.com\/@pierre\.meunier/,/https:\/\/medium\.com\/r\/.*/"
+readonly HTMLPROOFER_IGNORE_URLS=(
+  "/https:\/\/uk\.linkedin\.com\/in\/dashepherd/"
+  "/https:\/\/medium\.com\/@dave\.shepherd/"
+  "/https:\/\/dzone\.com\/articles\/creating-build-pipeline-using/"
+  "/https:\/\/medium\.com\/ww-engineering\/headers-propagation-with-hpropagate-27de8347f76a/"
+  "/https:\/\/medium\.com\/@pierre\.meunier/"
+  "/https:\/\/medium\.com\/r\/.*/"
+)
 
-bundle exec htmlproofer "$@" --ignore-urls "$HTMLPROOFER_IGNORE_URLS"
+HTMLPROOFER_IGNORE_URLS_JOINED="$(IFS=, ; echo "${HTMLPROOFER_IGNORE_URLS[*]}")"
+
+bundle exec htmlproofer "$@" --ignore-urls "$HTMLPROOFER_IGNORE_URLS_JOINED"


### PR DESCRIPTION
This pull request updates how HTML link checking is run in CI and local scripts, centralizing configuration and making it easier to maintain. It also fixes a documentation link in one of the blog posts. The most important changes are:

**Build and CI workflow improvements:**

* Replaces direct calls to `bundle exec htmlproofer` in `.github/workflows/build.yml`, `.github/workflows/nightly-link-check.yml`, and `scripts/local-check.sh` with a new wrapper script, `scripts/run-htmlproofer.sh`. This centralizes configuration and ensures consistent options are used across environments. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L45-R45) [[2]](diffhunk://#diff-343ad21a76e7de00ce36b8204ec94f27209b9ba0433b39877a0b918a2e921beeL27-R27) [[3]](diffhunk://#diff-393c6a96e44503e8da2d2b271e7fbb808671cd5c40a87e08f54e90e58c5d734cL29-R29)
* Adds the new `scripts/run-htmlproofer.sh` script, which runs `htmlproofer` with a predefined set of ignored URLs, improving maintainability and reducing false positives from known problematic links.

**Documentation fixes:**

* Updates outdated or indirect links in the post `_posts/2019-05-31-video-unblocking-the-release-train-with-istio-traffic-management.markdown` to use direct URLs for KubeCon and Istio, improving clarity for readers.