### PR TITLE
Change mergify reporting method to default

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -37,5 +37,3 @@ pull_request_rules:
       review:
         type: APPROVE
         message: Automatically approving projen upgrade
-merge_protections_settings:
-  reporting_method: check-runs


### PR DESCRIPTION
Remove the reporting_method configuration for mergify so that it's reported as a deploy which is now the default for Mergify.