### PR TITLE
chore(mergify): ensure mergify can merge without percy snapshots

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  statuses: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -92,6 +93,20 @@ jobs:
         run: npx percy snapshot _site/ |& tee /dev/stderr | grep -vzq "Build not created"
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+      - name: Set snapshot-skipped status
+        if: needs.changes.outputs.site != 'true' && github.event_name != 'workflow_dispatch'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commitSha = context.payload.pull_request?.head?.sha ?? context.sha;
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: commitSha,
+              state: 'success',
+              context: 'snapshot-skipped',
+              description: 'Percy snapshots skipped — no site files changed'
+            });
 
   # Deployment job
   deploy:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,7 +10,9 @@ queue_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=test
-      - status-success=percy/daveshepherd.github.io
+      - or:
+          - status-success=percy/daveshepherd.github.io
+          - status-success=snapshot-skipped
     merge_method: squash
     commit_message_template: |-
       {{ title }} (#{{ number }})
@@ -26,13 +28,17 @@ pull_request_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=test
-      - status-success=percy/daveshepherd.github.io
+      - or:
+          - status-success=percy/daveshepherd.github.io
+          - status-success=snapshot-skipped
   - name: Automatic approval for projen upgrade pull requests
     conditions:
       - author=dependabot[bot]
       - status-success=build
       - status-success=test
-      - status-success=percy/daveshepherd.github.io
+      - or:
+          - status-success=percy/daveshepherd.github.io
+          - status-success=snapshot-skipped
     actions:
       review:
         type: APPROVE


### PR DESCRIPTION
When site content isn't change percy snapshots aren't generated.

This pull request updates the CI workflow and merge rules to better handle cases where Percy visual snapshot tests are intentionally skipped (for example, when no site files have changed). The changes ensure that skipped Percy runs are clearly marked and do not block merges, improving both automation and transparency in the workflow.

**Workflow improvements for Percy snapshot handling:**

* Added a job step in `.github/workflows/build.yml` to set a commit status of `snapshot-skipped` with a descriptive message when Percy snapshots are skipped because no site files changed.
* Updated workflow permissions in `.github/workflows/build.yml` to allow writing commit statuses, enabling the new status to be set.

**Merge automation enhancements:**

* Modified `queue_rules` and `pull_request_rules` in `.mergify.yml` to accept either a successful Percy build status or a `snapshot-skipped` status, preventing unnecessary merge blocks when Percy is intentionally skipped. [[1]](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2R13-R15) [[2]](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2R31-R41)